### PR TITLE
Improve admin UX

### DIFF
--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -40,12 +40,9 @@ abstract class AbstractMenuNodeAdmin extends Admin
     protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
-            ->addIdentifier('id', 'text')
-            ->add('name', 'text')
+            ->addIdentifier('name', 'text')
             ->add('label', 'text')
-            ->add('uri', 'text')
-            ->add('route', 'text')
-            ;
+        ;
     }
 
     /**

--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -56,38 +56,6 @@ abstract class AbstractMenuNodeAdmin extends Admin
                 ->add('label', 'text')
             ->end()
         ;
-
-        if (null === $this->getParentFieldDescription()) {
-
-            // Add the choice for the node links "target"
-            $formMapper
-                ->with('form.group_general')
-                    ->add('linkType', 'choice_field_mask', array(
-                        'choices' => array(
-                            'route' => 'route',
-                            'uri' => 'uri',
-                            'content' => 'content',
-                        ),
-                        'map' => array(
-                            'route' => array('route'),
-                            'uri' => array('uri'),
-                            'content' => array('content', 'doctrine_phpcr_odm_tree'),
-                        ),
-                        'empty_value' => 'auto',
-                        'required' => false
-                    ))
-                    ->add('route', 'text', array('required' => false))
-                    ->add('uri', 'text', array('required' => false))
-                    ->add('content', 'doctrine_phpcr_odm_tree',
-                        array(
-                            'root_node' => $this->contentRoot,
-                            'choice_list' => array(),
-                            'required' => false
-                        )
-                    )
-                ->end()
-            ;
-        }
     }
 
     protected function configureShowFields(ShowMapper $showMapper)

--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -24,19 +24,19 @@ class MenuAdmin extends AbstractMenuNodeAdmin
         parent::configureFormFields($formMapper);
 
         $subject = $this->getSubject();
-        $isNew = $subject->getId() ? false : true;
+        $isNew = $subject->getId() === null;
 
-        if (false === $isNew) {
+        if (!$isNew) {
             $formMapper
                 ->with('form.group_items', array())
-                ->add('children', 'doctrine_phpcr_odm_tree_manager', array(
-                    'root' => $this->menuRoot,
-                    'edit_in_overlay' => false,
-                    'create_in_overlay' => false,
-                    'delete_in_overlay' => false
-                ), array(
-                    'help' => 'help.items_help'
-                ))
+                    ->add('children', 'doctrine_phpcr_odm_tree_manager', array(
+                        'root' => $this->menuRoot,
+                        'edit_in_overlay' => false,
+                        'create_in_overlay' => false,
+                        'delete_in_overlay' => false,
+                    ), array(
+                        'help' => 'help.items_help',
+                    ))
                 ->end()
             ;
         }

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -54,7 +54,6 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
         parent::configureFormFields($formMapper);
 
         if (null === $this->getParentFieldDescription()) {
-
             // Add the choice for the node links "target"
             $formMapper
                 ->with('form.group_general')
@@ -88,6 +87,10 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
         parent::defineFormBuilder($formBuilder);
 
         $formBuilder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+            if (!$event->getForm()->has('link')) {
+                return;
+            }
+
             $link = $event->getForm()->get('link');
             $node = $event->getData();
 
@@ -119,6 +122,10 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
         });
 
         $formBuilder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+            if (!$event->getForm()->has('link')) {
+                return;
+            }
+
             $form = $event->getForm();
             $node = $event->getData();
 

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
+use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
 use Symfony\Cmf\Bundle\MenuBundle\Model\Menu;
@@ -20,6 +21,16 @@ use Doctrine\Common\Util\ClassUtils;
 class MenuNodeAdmin extends AbstractMenuNodeAdmin
 {
     protected $recursiveBreadcrumbs = true;
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        parent::configureListFields($listMapper);
+
+        $listMapper
+            ->add('uri', 'text')
+            ->add('route', 'text')
+        ;
+    }
 
     /**
      * {@inheritDoc}

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
-use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -83,7 +83,7 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
     /**
      * {@inheritdoc}
      */
-    public function defineFormBuilder(FormBuilderInterface $formBuilder)
+    public function defineFormBuilder(FormBuilder $formBuilder)
     {
         parent::defineFormBuilder($formBuilder);
 

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -46,7 +46,35 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
                 )
             ->end()
         ;
+
         parent::configureFormFields($formMapper);
+
+        if (null === $this->getParentFieldDescription()) {
+
+            // Add the choice for the node links "target"
+            $formMapper
+                ->with('form.group_general')
+                    ->add('linkType', 'choice_field_mask', array(
+                        'map' => array(
+                            'route' => array('route'),
+                            'uri' => array('uri'),
+                            'content' => array('content', 'doctrine_phpcr_odm_tree'),
+                        ),
+                        'empty_value' => 'auto',
+                        'required' => false
+                    ))
+                    ->add('route', 'text', array('required' => false))
+                    ->add('uri', 'text', array('required' => false))
+                    ->add('content', 'doctrine_phpcr_odm_tree',
+                        array(
+                            'root_node' => $this->contentRoot,
+                            'choice_list' => array(),
+                            'required' => false
+                        )
+                    )
+                ->end()
+            ;
+        }
     }
 
     /**

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -39,11 +39,11 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
     {
         $formMapper
             ->with('form.group_general')
-                ->add(
-                    'parent',
-                    'doctrine_phpcr_odm_tree',
-                    array('root_node' => $this->menuRoot, 'choice_list' => array(), 'select_root_node' => true)
-                )
+                ->add('parent', 'doctrine_phpcr_odm_tree', array(
+                    'root_node' => $this->menuRoot,
+                    'choice_list' => array(),
+                    'select_root_node' => true
+                ))
             ->end()
         ;
 

--- a/Resources/translations/CmfMenuBundle.cs.xliff
+++ b/Resources/translations/CmfMenuBundle.cs.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Rodič</target>
+        <target>Menu</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Resources/translations/CmfMenuBundle.de.xliff
+++ b/Resources/translations/CmfMenuBundle.de.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Übergeordnet</target>
+        <target>Menüs</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Resources/translations/CmfMenuBundle.en.xliff
+++ b/Resources/translations/CmfMenuBundle.en.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Parent</target>
+        <target>Menu</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Resources/translations/CmfMenuBundle.fr.xliff
+++ b/Resources/translations/CmfMenuBundle.fr.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Parent</target>
+        <target>Menus</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Resources/translations/CmfMenuBundle.sk.xliff
+++ b/Resources/translations/CmfMenuBundle.sk.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Rodič</target>
+        <target>Menu</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Resources/translations/CmfMenuBundle.sl.xliff
+++ b/Resources/translations/CmfMenuBundle.sl.xliff
@@ -80,7 +80,7 @@
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>
-        <target>Vrhnji</target>
+        <target>Meniji</target>
       </trans-unit>
       <trans-unit id="form.label_name">
         <source>form.label_name</source>

--- a/Tests/WebTest/Admin/Extension/MenuNodeReferrersExtensionTest.php
+++ b/Tests/WebTest/Admin/Extension/MenuNodeReferrersExtensionTest.php
@@ -27,7 +27,7 @@ class MenuNodeReferrersExtensionTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu-test/content/test/content-1/edit');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertResponseSuccess($res);
 
         $button = $crawler->selectButton('Update');
         $form = $button->form();

--- a/Tests/WebTest/Admin/MenuAdminTest.php
+++ b/Tests/WebTest/Admin/MenuAdminTest.php
@@ -28,7 +28,7 @@ class MenuAdminTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menu/list');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode(), $res->getContent());
+        $this->assertResponseSuccess($res);
         $this->assertCount(1, $crawler->filter('html:contains("test-menu")'), $res->getContent());
     }
 
@@ -36,7 +36,7 @@ class MenuAdminTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menu/test/menus/test-menu/edit');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode(), $res->getContent());
+        $this->assertResponseSuccess($res);
         $this->assertCount(1, $crawler->filter('input[value="test-menu"]'), $res->getContent());
     }
 
@@ -44,7 +44,7 @@ class MenuAdminTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menu/test/menus/test-menu/show');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode(), $res->getContent());
+        $this->assertResponseSuccess($res);
         $this->assertCount(2, $crawler->filter('td:contains("test-menu")'), $res->getContent());
     }
 
@@ -52,7 +52,7 @@ class MenuAdminTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menu/create');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode(), $res->getContent());
+        $this->assertResponseSuccess($res);
 
         $button = $crawler->selectButton('Create');
         $form = $button->form();
@@ -74,7 +74,7 @@ class MenuAdminTest extends BaseTestCase
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menu/test/menus/test-menu/delete');
         $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertResponseSuccess($res);
 
         $button = $crawler->selectButton('Yes, delete');
         $form = $button->form();

--- a/Tests/WebTest/Admin/MenuNodeAdminTest.php
+++ b/Tests/WebTest/Admin/MenuNodeAdminTest.php
@@ -26,15 +26,14 @@ class MenuNodeAdminTest extends BaseTestCase
     public function testEdit()
     {
         $this->client->request('GET', '/admin/cmf/menu/menunode/test/menus/test-menu/item-1/edit');
-        $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
+
+        $this->assertResponseSuccess($this->client->getResponse());
     }
 
     public function testDelete()
     {
         $crawler = $this->client->request('GET', '/admin/cmf/menu/menunode/test/menus/test-menu/item-2/delete');
-        $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertResponseSuccess($this->client->getResponse());
 
         $button = $crawler->selectButton('Yes, delete');
         $form = $button->form();

--- a/Tests/WebTest/Render/TwigTest.php
+++ b/Tests/WebTest/Render/TwigTest.php
@@ -27,9 +27,8 @@ class TwigTest extends BaseTestCase
     {
         $client = $this->createClient();
         $crawler = $client->request('GET', '/render-test');
-        $res = $client->getResponse();
 
-        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertResponseSuccess($client->getResponse());
         $this->assertMenuHasItems($crawler->filter('#content ul')->eq(0), array(
             'This node has a URI',
             '@todo this node should have content',

--- a/Tests/WebTest/Voter/RequestContentIdentityVoterTest.php
+++ b/Tests/WebTest/Voter/RequestContentIdentityVoterTest.php
@@ -19,9 +19,9 @@ class RequestContentIdentityVoterTest extends BaseTestCase
         // the URL of the content is the same as the URL for the menu item anyway
         // so it works by default
         $crawler = $this->client->request('GET', '/contents/content-1');
-        $res = $this->client->getResponse();
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'Request Content Identity Voter');
-        $this->assertEquals(200, $res->getStatusCode());
     }
 
     public function testRequestContentIdentityVoter()
@@ -30,8 +30,8 @@ class RequestContentIdentityVoterTest extends BaseTestCase
         // the URL is different from that of the content, so if the menu item
         // is highlighted, it is because the voter is working.
         $crawler = $this->client->request('GET', '/cmi/request_content_identity');
-        $res = $this->client->getResponse();
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'Request Content Identity Voter');
-        $this->assertEquals(200, $res->getStatusCode());
     }
 }

--- a/Tests/WebTest/Voter/RequestParentContentIdentityVoterTest.php
+++ b/Tests/WebTest/Voter/RequestParentContentIdentityVoterTest.php
@@ -19,17 +19,17 @@ class RequestParentContentIdentityVoterTest extends BaseTestCase
         // to the "Request Content PArent Identity" menu item and so DOES NOT invoke
         // the voter.
         $crawler = $this->client->request('GET', '/blog');
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'Request Parent Content Identity Voter');
-        $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
     }
 
     public function testRequestContentParentIdentity()
     {
         // this test shows an post whose parent is the blog content referenced in the menu item
         $crawler = $this->client->request('GET', '/blog/my-post');
-        $res = $this->client->getResponse();
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'Request Parent Content Identity Voter');
-        $this->assertEquals(200, $res->getStatusCode());
     }
 }

--- a/Tests/WebTest/Voter/UriPrefixVoterTest.php
+++ b/Tests/WebTest/Voter/UriPrefixVoterTest.php
@@ -19,9 +19,9 @@ class UriPrefixVoterTest extends BaseTestCase
         // to the "URI Prefix Voter" menu item and so DOES NOT invoke
         // the voter.
         $crawler = $this->client->request('GET', '/articles');
-        $res = $this->client->getResponse();
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'URI Prefix Voter');
-        $this->assertEquals(200, $res->getStatusCode());
     }
 
     public function testUriPrefixArticle()
@@ -29,8 +29,8 @@ class UriPrefixVoterTest extends BaseTestCase
         // this test shows an article which contains the prefix in the "/articles" route
         // as currentUriPrefix, and so the Voter IS used and the item should be selected.
         $crawler = $this->client->request('GET', '/articles/some-category/article-1');
-        $res = $this->client->getResponse();
+
+        $this->assertResponseSuccess($this->client->getResponse());
         $this->assertCurrentItem($crawler, 'URI Prefix Voter');
-        $this->assertEquals(200, $res->getStatusCode());
     }
 }


### PR DESCRIPTION
Menus was, and still is, one of less easy to use admin interface. This PR tries to fix it a bit.

I changed 2 main things;

* Menu admin only shows name + label + menu items, there is no reason to show linking stuff and such in here
* MenuNode admin does no longer show a "route" and "uri" field, but it shows one "link" field instead. The linkType select input will determine what the value of "link" is (if it's a route or uri)