### PR TITLE
Decode request URI before setting on menu

### DIFF
--- a/Provider/PhpcrMenuProvider.php
+++ b/Provider/PhpcrMenuProvider.php
@@ -169,7 +169,7 @@ class PhpcrMenuProvider implements MenuProviderInterface
             throw new \InvalidArgumentException("Menu at '$name' is misconfigured (f.e. the route might be incorrect) and could therefore not be instanciated");
         }
 
-        $menuItem->setCurrentUri($this->request->getRequestUri());
+        $menuItem->setCurrentUri(rawurldecode($this->request->getRequestUri()));
 
         return $menuItem;
     }


### PR DESCRIPTION
Percent-encoded characters in the request URI must be decoded in order for matches to be correctly performed against values stored in the repository.  Not sure whether it would be more correct to decode within `Knp\Menu\ItemInterface::setCurrentUri()`—probably not?