### PR TITLE
prevent exceptions on menu names that are not valid node names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       env: SYMFONY_VERSION=2.6.*
 
 before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - composer self-update
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh

--- a/Provider/PhpcrMenuProvider.php
+++ b/Provider/PhpcrMenuProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Provider;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use PHPCR\RepositoryException;
 use Symfony\Component\HttpFoundation\Request;
 use PHPCR\PathNotFoundException;
 use PHPCR\Util\PathHelper;
@@ -214,9 +215,20 @@ class PhpcrMenuProvider implements MenuProviderInterface
             return false;
         }
 
-        $path = PathHelper::absolutizePath($name, $this->getMenuRoot());
         $dm = $this->getObjectManager();
         $session = $dm->getPhpcrSession();
+
+        try {
+            $path = PathHelper::absolutizePath($name, $this->getMenuRoot());
+            PathHelper::assertValidAbsolutePath($path, false, true, $session->getNamespacePrefixes());
+        } catch (RepositoryException $e) {
+            if ($throw) {
+                throw $e;
+            }
+
+            return false;
+        }
+
         if ($this->getPrefetch() > 0) {
             try {
                 if (


### PR DESCRIPTION
fix #223
cc @ahmadrabie 

once merged, we also need to merge 1.2 into master to fix version 2