### PR TITLE
Set the request in the parent admin when building breadcrumbs

### DIFF
--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -60,6 +60,7 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
         }
 
         $parentAdmin->setSubject($parentDoc);
+        $parentAdmin->setRequest($this->request);
         $parentEditNode = $parentAdmin->buildBreadcrumbs($action, $menu);
         if ($parentAdmin->isGranted('EDIT' && $parentAdmin->hasRoute('edit'))) {
             $parentEditNode->setUri(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

I'm currently working on [this PR](https://github.com/sonata-project/SonataAdminBundle/pull/3258) and the missing request in the admin causes an issue.

This PR simply set the request in the admin.